### PR TITLE
Update 3

### DIFF
--- a/WaveCOM/Config/XComWaveCOM.ini
+++ b/WaveCOM/Config/XComWaveCOM.ini
@@ -3,6 +3,10 @@
 ;Alter the supply cost ratio against research points. This should always be below 1, for reference much of the
 ;starting research is around 720 research points, so 0.1 = 72 supplies cost
 WaveCOMResearchSupplyCostRatio=0.1
++NonUpgradeSchematics=HunterRifle_CV_Schematic
++NonUpgradeSchematics=HunterPistol_CV_Schematic
++NonUpgradeSchematics=HunterAxe_CV_Schematic
++NonUpgradeSchematics=Frostbomb_Schematic
 
 [WaveCOM.WaveCOMStrategy]
 WaveCOMStartingSupplies=500

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UIArmory_FieldLoadout.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UIArmory_FieldLoadout.uc
@@ -292,7 +292,6 @@ function Push_UIArmory_Promotion(StateObjectReference UnitRef, optional bool bIn
 			}
 			UnitState.ApplySquaddieLoadout(NewGameState, XComHQ);
 			UnitState.ApplyBestGearLoadout(NewGameState); // Make sure the squaddie has the best gear available
-			UpdateUnitState(UnitState.ObjectID, NewGameState);
 		}
 		UnitState.ValidateLoadout(NewGameState);
 	}

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_ListenForUnitReward.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_ListenForUnitReward.uc
@@ -1,0 +1,36 @@
+class WaveCOM_UISL_ListenForUnitReward extends UIScreenListener;
+
+event OnInit(UIScreen Screen)
+{
+	local Object this;
+
+	this = self;
+	`XEVENTMGR.RegisterForEvent(this, 'ResearchCompleted', ResearchComplete, ELD_OnStateSubmitted);
+}
+
+function EventListenerReturn ResearchComplete(Object EventData, Object EventSource, XComGameState GameState, Name EventID)
+{
+	local XComGameState_Tech TechState;
+	local XComGameState_Unit StrategyUnit;
+
+	TechState = XComGameState_Tech(EventData);
+
+	`log("Research Complete",, 'UnitProject');
+
+	if (TechState != none && TechState.UnitRewardRef.ObjectID > 0)
+	{
+		`log("Tech contains unit",, 'UnitProject');
+		StrategyUnit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(TechState.UnitRewardRef.ObjectID));
+		if (StrategyUnit != none)
+		{
+			class'WaveCOM_UILoadoutButton'.static.AddStrategyUnitToBoard(StrategyUnit, `XCOMHISTORY);
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+defaultproperties
+{
+	ScreenClass=class'UITacticalHUD';
+}

--- a/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
@@ -118,10 +118,10 @@ static function UpgradeItems(XComGameState NewGameState, XComGameState_Item Item
 	local array<XComGameState_Unit> Soldiers;
 	local EInventorySlot InventorySlot;
 	local XGItem ItemVisualizer;
-	local XComNarrativeMoment EquipNarrativeMoment;
 	local XComGameState_Unit HighestRankSoldier;
 	local int idx, iSoldier, iItems;
 	local name CreatorTemplateName;
+	local XGUnit Visualizer;
 
 	CreatorTemplateName = ItemState.GetMyTemplateName();
 
@@ -248,26 +248,17 @@ static function UpgradeItems(XComGameState NewGameState, XComGameState_Item Item
 						// Then add the new item to the soldier in the same slot
 						Soldiers[iSoldier].AddItemToInventory(UpgradedItemState, InventorySlot, NewGameState);
 
-						// Store the highest ranking soldier to get the upgraded item
-						if (HighestRankSoldier == none || Soldiers[iSoldier].GetRank() > HighestRankSoldier.GetRank())
-						{
-							HighestRankSoldier = Soldiers[iSoldier];
-						}
+						Visualizer = XGUnit(Soldiers[iSoldier].FindOrCreateVisualizer());
+						Soldiers[iSoldier].SyncVisualizer(NewGameState);
+						Visualizer.ApplyLoadoutFromGameState(Soldiers[iSoldier], NewGameState);
+
+						class'WaveCOM_UIArmory_FieldLoadout'.static.UpdateUnitState(Soldiers[iSoldier].ObjectID, NewGameState);
 					}
 				}
 			}
 		}
 
-		// Play a narrative if there is one and there is a valid soldier
-		if (HighestRankSoldier != none && X2EquipmentTemplate(UpgradeItemTemplate).EquipNarrative != "")
-		{
-			EquipNarrativeMoment = XComNarrativeMoment(`CONTENT.RequestGameArchetype(X2EquipmentTemplate(UpgradeItemTemplate).EquipNarrative));
-			if (EquipNarrativeMoment != None && XComHQ.CanPlayArmorIntroNarrativeMoment(EquipNarrativeMoment))
-			{
-				XComHQ.UpdatePlayedArmorIntroNarrativeMoments(EquipNarrativeMoment);
-				`HQPRES.UIArmorIntroCinematic(EquipNarrativeMoment.nmRemoteEvent, 'CIN_ArmorIntro_Done', HighestRankSoldier.GetReference());
-			}
-		}
+		// Remove narratives to prevent problems
 	}
 }
 

--- a/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
@@ -11,6 +11,7 @@
 class X2DownloadableContentInfo_WaveCOM extends X2DownloadableContentInfo config(WaveCOM);
 
 var const config float WaveCOMResearchSupplyCostRatio;
+var array<name> NonUpgradeSchematics;
 
 static event OnPostTemplatesCreated()
 {
@@ -97,10 +98,13 @@ static function UpdateSchematicTemplates ()
 	Schematics = Manager.GetAllSchematicTemplates();
 	foreach Schematics(Schematic)
 	{
-		`log("Updating: " @Schematic.DataName);
-		Schematic.OnBuiltFn = UpgradeItems;
+		if (default.NonUpgradeSchematics.Find(Schematic.DataName) == INDEX_NONE)
+		{
+			`log("Updating: " @Schematic.DataName);
+			Schematic.OnBuiltFn = UpgradeItems;
 
-		Manager.AddItemTemplate(Schematic, true);
+			Manager.AddItemTemplate(Schematic, true);
+		}
 	}
 }
 
@@ -118,7 +122,6 @@ static function UpgradeItems(XComGameState NewGameState, XComGameState_Item Item
 	local array<XComGameState_Unit> Soldiers;
 	local EInventorySlot InventorySlot;
 	local XGItem ItemVisualizer;
-	local XComGameState_Unit HighestRankSoldier;
 	local int idx, iSoldier, iItems;
 	local name CreatorTemplateName;
 	local XGUnit Visualizer;

--- a/WaveCOM/Src/XComMissionLogic/Classes/X2DownloadableContentInfo_XComMissionLogic.uc
+++ b/WaveCOM/Src/XComMissionLogic/Classes/X2DownloadableContentInfo_XComMissionLogic.uc
@@ -33,9 +33,18 @@ static event OnLoadedSavedGame()
 static event InstallNewCampaign(XComGameState StartState)
 {
 	local XComMissionLogic_Listener MissionListener;
+	local XComGameState_CampaignSettings CampaignSettings;
 	MissionListener = XComMissionLogic_Listener(StartState.CreateStateObject(class'XComMissionLogic_Listener'));
 	MissionListener.RegisterToListen();
 	StartState.AddStateObject(MissionListener);
 
 	`log("XComMissionLogic :: InstallNewCampaign");
+
+
+	// Removing all nerative content, so techs can be accessed from the mission
+	foreach StartState.IterateByClassType(class'XComGameState_CampaignSettings', CampaignSettings)
+	{
+		break;
+	}
+	CampaignSettings.RemoveAllOptionalNarrativeDLC();
 }

--- a/WaveCOM/Src/XComMissionLogic/Classes/XComMissionLogic_Listener.uc
+++ b/WaveCOM/Src/XComMissionLogic/Classes/XComMissionLogic_Listener.uc
@@ -50,5 +50,6 @@ function EventListenerReturn LoadRelevantMissionLogic(Object EventData, Object E
 		}
 	}
 	`log("XComMissionLogic :: Loaded Mission Logic");
+
 	return ELR_NoInterrupt;
 }

--- a/WaveCOM/WaveCOM.x2proj
+++ b/WaveCOM/WaveCOM.x2proj
@@ -103,6 +103,9 @@ Known Issues
     <Content Include="Src\WaveCOM\Classes\WaveCOM_UILoadoutButton.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\WaveCOM\Classes\WaveCOM_UISL_ListenForUnitReward.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\WaveCOM\Classes\X2DownloadableContentInfo_WaveCOM.uc" />
     <Content Include="Src\XComMissionLogic\Classes\X2DownloadableContentInfo_XComMissionLogic.uc">
       <SubType>Content</SubType>


### PR DESCRIPTION
- Now places unit to tactical map if a unit is rewarded from a research project (such as SPARKs)
- Upgrading items now properly update their bearer's abilities and visualization, eliminating the double equip bug without entering and exiting the loadout screen.
- If for some reason a unit cannot be placed on the tactical map, the cost is now refunded and an error message will be shown
- Promoted rookies will now equip their appropriate items.
- Alien hunter items are now buildable
