### PR TITLE
Spark cost update

### DIFF
--- a/WaveCOM/Config/XComWaveCOM.ini
+++ b/WaveCOM/Config/XComWaveCOM.ini
@@ -15,6 +15,8 @@ WaveCOMResearchSupplyCostRatio=0.1
 +CantSellResource=EleriumDust
 +CantSellResource=AlienAlloy
 
++RepeatableUpgradeCosts=(UpgradeName=BuildSpark, SupplyIncrement=200, SupplyMax=2000, ScaleWithSquadSize=true, FirstIncrease=4)
+
 [WaveCOM.WaveCOMStrategy]
 WaveCOMStartingSupplies=500
 

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
@@ -18,12 +18,8 @@ simulated function InitScreen(UIScreen ScreenParent)
 
 	CurrentDeployCost = 50;
 
-	if (!class'X2DownloadableContentInfo_WaveCOM'.default.CostUpdated)
-	{
-		class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchTemplates();
-		class'X2DownloadableContentInfo_WaveCOM'.static.UpdateSchematicTemplates();
-		class'X2DownloadableContentInfo_WaveCOM'.default.CostUpdated = true;
-	}
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchTemplates();
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateSchematicTemplates();
 
 	TacHUDScreen = UITacticalHUD(ScreenParent);
 	`log("Loading my button thing.");

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
@@ -18,8 +18,12 @@ simulated function InitScreen(UIScreen ScreenParent)
 
 	CurrentDeployCost = 50;
 
-	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchTemplates();
-	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateSchematicTemplates();
+	if (!class'X2DownloadableContentInfo_WaveCOM'.default.CostUpdated)
+	{
+		class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchTemplates();
+		class'X2DownloadableContentInfo_WaveCOM'.static.UpdateSchematicTemplates();
+		class'X2DownloadableContentInfo_WaveCOM'.default.CostUpdated = true;
+	}
 
 	TacHUDScreen = UITacticalHUD(ScreenParent);
 	`log("Loading my button thing.");
@@ -102,6 +106,8 @@ simulated function InitScreen(UIScreen ScreenParent)
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'UpdateDeployCost', OnDeath, ELD_Immediate);
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'UpdateDeployCostDelayed', OnDeath, ELD_OnStateSubmitted);
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'ResearchCompleted', UpdateResourceHUD, ELD_OnStateSubmitted);
+	`XEVENTMGR.RegisterForEvent(ThisObj, 'ResearchCompleted', UpdateTechCost, ELD_OnStateSubmitted);
+	`XEVENTMGR.RegisterForEvent(ThisObj, 'UpdateResearchCost', UpdateTechCost, ELD_OnStateSubmitted);
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'ItemConstructionCompleted', UpdateResourceHUD, ELD_OnStateSubmitted);
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'PsiTrainingUpdate', UpdateResourceHUD, ELD_OnStateSubmitted);
 	`XEVENTMGR.RegisterForEvent(ThisObj, 'BlackMarketGoodsSold', UpdateResourceHUD, ELD_OnStateSubmitted);
@@ -129,7 +135,7 @@ public function XComGameState_Unit GetNonDeployedSoldier()
 	return none;
 }
 
-private function UpdateDeployCost ()
+private function int UpdateDeployCost ()
 {
 	local XComGameState_Unit UnitState;
 	local int XComCount;
@@ -167,6 +173,8 @@ private function UpdateDeployCost ()
 		Button6.SetText("Deploy Soldier - " @CurrentDeployCost);
 	}
 
+	return XComCount;
+
 }
 
 private function EventListenerReturn OnDeath(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID)
@@ -193,6 +201,26 @@ private function EventListenerReturn OnWaveEnd(Object EventData, Object EventSou
 private function EventListenerReturn UpdateResourceHUD(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID)
 {
 	UpdateResources();
+	return ELR_NoInterrupt;
+}
+
+private function EventListenerReturn UpdateTechCost(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID)
+{
+	local int NumSoldier;
+	local UISimpleCommodityScreen ProjectScreen;
+	NumSoldier = UpdateDeployCost();
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
+
+	// Refresh foreground
+	ProjectScreen = UISimpleCommodityScreen(TacHUDScreen.Movie.Stack.GetFirstInstanceOf(class'UIChooseProject'));
+	if (ProjectScreen == none)
+		ProjectScreen = UISimpleCommodityScreen(TacHUDScreen.Movie.Stack.GetFirstInstanceOf(class'UIChooseResearch'));
+	if (ProjectScreen != none)
+	{
+		ProjectScreen.GetItems();
+		ProjectScreen.PopulateData();
+	}
+
 	return ELR_NoInterrupt;
 }
 
@@ -253,7 +281,10 @@ public function OpenBlackMarket(UIButton Button)
 public function OpenResearchMenu(UIButton Button)
 {
 	local UIChooseResearch LoadedScreen;
+	local int NumSoldier;
 	UpdateResources();
+	NumSoldier = UpdateDeployCost();
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
 	LoadedScreen = TacHUDScreen.Movie.Pres.Spawn(class'UIChooseResearch', TacHUDScreen.Movie.Pres);
 	TacHUDScreen.Movie.Stack.Push(LoadedScreen, TacHUDScreen.Movie);
 }
@@ -261,7 +292,10 @@ public function OpenResearchMenu(UIButton Button)
 public function OpenProjectMenu(UIButton Button)
 {
 	local UIChooseProject LoadedScreen;
+	local int NumSoldier;
 	UpdateResources();
+	NumSoldier = UpdateDeployCost();
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
 	LoadedScreen = TacHUDScreen.Movie.Pres.Spawn(class'UIChooseProject', TacHUDScreen.Movie.Pres);
 	TacHUDScreen.Movie.Stack.Push(LoadedScreen, TacHUDScreen.Movie);
 }

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_ListenForUnitReward.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_ListenForUnitReward.uc
@@ -68,6 +68,7 @@ function EventListenerReturn ResearchComplete(Object EventData, Object EventSour
 			}
 		}
 		`XEVENTMGR.TriggerEvent('UpdateDeployCost');
+		`XEVENTMGR.TriggerEvent('UpdateResearchCost');
 	}
 
 	return ELR_NoInterrupt;

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_PauseMenuHook.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UISL_PauseMenuHook.uc
@@ -1,0 +1,43 @@
+class WaveCOM_UISL_PauseMenuHook extends UIScreenListener;
+
+event OnInit(UIScreen Screen)
+{
+	local WaveCOM_MissionLogic_WaveCOM MissionLogic;
+	if (UIPauseMenu(Screen) == none)
+		return;
+		
+	MissionLogic = WaveCOM_MissionLogic_WaveCOM(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'WaveCOM_MissionLogic_WaveCOM'));
+	//`log("Pause menu detected",, 'PauseTransferHook');
+	if (MissionLogic != none)
+	{
+		//`log("Mission Logic detected",, 'PauseTransferHook');
+		if (MissionLogic.WaveStatus == eWaveStatus_Preparation)
+		{
+			//`log("Transfer button created",, 'PauseTransferHook');
+			Screen.Spawn(class'UIButton', Screen).InitButton('btnTransferMission', "Transfer to new map", TransferMission).AnchorTopRight().SetPosition(0 - 300, 20);
+		}
+	}
+}
+
+simulated function TransferMission(UIButton ButtonClicked)
+{
+	local TDialogueBoxData DialogData;
+
+	DialogData.eType = eDialog_Alert;
+	DialogData.bMuteAcceptSound = true;
+	DialogData.strTitle = "Confirm transfer mission";
+	DialogData.strAccept = class'UIUtilities_Text'.default.m_strGenericYes;
+	DialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericNO;
+	DialogData.strText = "Do you want to transfer all units to a new map? This can fix performance issues and generate a new undestroyed map.\nNote that if you have more units than the spawn point can handle, you need to deploy the extra soldiers manually after freeing up the initial space.";
+	DialogData.fnCallback = ComfirmMissionTransfer;
+	`PRES.UIRaiseDialog(DialogData);
+}
+
+
+simulated function ComfirmMissionTransfer(EUIAction Action)
+{
+	if(Action == eUIAction_Accept)
+	{
+		class'X2DownloadableContentInfo_WaveCOM'.static.StaticWaveCOMMissionTransfer();
+	}
+}

--- a/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/X2DownloadableContentInfo_WaveCOM.uc
@@ -26,7 +26,6 @@ struct DynamicUpgradeData
 };
 
 var config array<DynamicUpgradeData> RepeatableUpgradeCosts;
-var config bool CostUpdated; // Please do not add this config to INI, also never ever save the config of this class
 
 static event OnPostTemplatesCreated()
 {
@@ -177,23 +176,26 @@ static function UpdateResearchTemplates ()
 	Techs = Manager.GetAllTemplatesOfClass(class'X2TechTemplate');
 	foreach Techs(TechTemplate)
 	{
-		Tech = X2TechTemplate(TechTemplate);
-		BasePoints = Tech.PointsToComplete;
-		AddSupplyCost(Tech.Cost.ResourceCosts, Round(BasePoints * default.WaveCOMResearchSupplyCostRatio));
-		Tech.bJumpToLabs = false;
-		Tech.PointsToComplete = 0;
-		Manager.AddStrategyElementTemplate(Tech, true);
-
-		UpgradeIndex = default.RepeatableUpgradeCosts.Find('UpgradeName', Tech.DataName);
-
-		if (UpgradeIndex != INDEX_NONE)
+		if (Tech.PointsToComplete > 0)
 		{
-			CostData = default.RepeatableUpgradeCosts[UpgradeIndex];
+			Tech = X2TechTemplate(TechTemplate);
+			BasePoints = Tech.PointsToComplete;
+			AddSupplyCost(Tech.Cost.ResourceCosts, Round(BasePoints * default.WaveCOMResearchSupplyCostRatio));
+			Tech.bJumpToLabs = false;
+			Tech.PointsToComplete = 0;
+			Manager.AddStrategyElementTemplate(Tech, true);
 
-			CostData.BaseCost = Tech.Cost;
+			UpgradeIndex = default.RepeatableUpgradeCosts.Find('UpgradeName', Tech.DataName);
 
-			default.RepeatableUpgradeCosts.Remove(UpgradeIndex, 1);
-			default.RepeatableUpgradeCosts.AddItem(CostData);
+			if (UpgradeIndex != INDEX_NONE)
+			{
+				CostData = default.RepeatableUpgradeCosts[UpgradeIndex];
+
+				CostData.BaseCost = Tech.Cost;
+
+				default.RepeatableUpgradeCosts.Remove(UpgradeIndex, 1);
+				default.RepeatableUpgradeCosts.AddItem(CostData);
+			}
 		}
 	}
 }

--- a/WaveCOM/WaveCOM.x2proj
+++ b/WaveCOM/WaveCOM.x2proj
@@ -139,6 +139,9 @@ Known Issues
     <Content Include="Src\WaveCOM\Classes\WaveCOM_UISL_ListenForUnitReward.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\WaveCOM\Classes\WaveCOM_UISL_PauseMenuHook.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\WaveCOM\Classes\X2DownloadableContentInfo_WaveCOM.uc" />
     <Content Include="Src\XComMissionLogic\Classes\X2DownloadableContentInfo_XComMissionLogic.uc">
       <SubType>Content</SubType>


### PR DESCRIPTION
Merge #10 first

- Sparks now cost based on your squad size (+200 supplies cost for each extra member beyond the 4th, capped at +2000 additional supplies cost)
- ~~Fixed a bug where tech cost keep increases if you unload and reload tactical HUD by any means (such as returning to main menu and come back without closing the game)~~ (This bug actually don't exist as the point to complete is 0 so the resource cost is increased by 0, but I still need to add a check to it as the dynamic cost researches needs to cache properly)
- Fixed a bug where upgrading SPARK armor causes freezes
- Added Transfer to new map button in pause menu, this button is only available between waves
- You may now recruit high rank soldiers from black market, they cost the same amount of supplies as normal soldiers in addition to the standard intel cost. This should help recovery from casualties as this game does not have experience scaling.