### PR TITLE
July Update

### DIFF
--- a/WaveCOM/Config/XComGameCore.ini
+++ b/WaveCOM/Config/XComGameCore.ini
@@ -3,6 +3,6 @@
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_02", Loots[0]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketUpgrades_02",RollGroup=1), Loots[1]=(Chance=100,MinCount=1,MaxCount=2,TableRef="BlackMarketPCS_02",RollGroup=2) )
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_03", Loots[0]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketUpgrades_03",RollGroup=1), Loots[1]=(Chance=100,MinCount=1,MaxCount=2,TableRef="BlackMarketPCS_03",RollGroup=2) )
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_04", Loots[0]=(Chance=100,MinCount=3,MaxCount=4,TableRef="BlackMarketUpgrades_03",RollGroup=1), Loots[1]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketPCS_03",RollGroup=2) )
-+GlobalLootCarriers=(CarrierName="WaveCOMBlackMarket", LootReferences[0]=(LootTableName="WaveCOMBlackMarketLoot_01", ForceLevel=0), LootReferences[1]=(LootTableName="WaveCOMBlackMarketLoot_02", ForceLevel=6), LootReferences[2]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=9), LootReferences[3]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=15))
++GlobalLootCarriers=(CarrierName="WaveCOMBlackMarket", LootReferences[0]=(LootTableName="WaveCOMBlackMarketLoot_01", ForceLevel=0), LootReferences[1]=(LootTableName="WaveCOMBlackMarketLoot_02", ForceLevel=6), LootReferences[2]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=9), LootReferences[3]=(LootTableName="WaveCOMBlackMarketLoot_04", ForceLevel=15))
 
 ; Avoid making black market sell elerium shards and alloys.

--- a/WaveCOM/Config/XComGameCore.ini
+++ b/WaveCOM/Config/XComGameCore.ini
@@ -3,6 +3,6 @@
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_02", Loots[0]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketUpgrades_02",RollGroup=1), Loots[1]=(Chance=100,MinCount=1,MaxCount=2,TableRef="BlackMarketPCS_02",RollGroup=2) )
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_03", Loots[0]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketUpgrades_03",RollGroup=1), Loots[1]=(Chance=100,MinCount=1,MaxCount=2,TableRef="BlackMarketPCS_03",RollGroup=2) )
 +LootTables=( TableName = "WaveCOMBlackMarketLoot_04", Loots[0]=(Chance=100,MinCount=3,MaxCount=4,TableRef="BlackMarketUpgrades_03",RollGroup=1), Loots[1]=(Chance=100,MinCount=2,MaxCount=3,TableRef="BlackMarketPCS_03",RollGroup=2) )
-+GlobalLootCarriers=(CarrierName="WaveCOMBlackMarket", LootReferences[0]=(LootTableName="WaveCOMBlackMarketLoot_01", ForceLevel=0), LootReferences[1]=(LootTableName="WaveCOMBlackMarketLoot_02", ForceLevel=6), LootReferences[2]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=9), LootReferences[2]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=15))
++GlobalLootCarriers=(CarrierName="WaveCOMBlackMarket", LootReferences[0]=(LootTableName="WaveCOMBlackMarketLoot_01", ForceLevel=0), LootReferences[1]=(LootTableName="WaveCOMBlackMarketLoot_02", ForceLevel=6), LootReferences[2]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=9), LootReferences[3]=(LootTableName="WaveCOMBlackMarketLoot_03", ForceLevel=15))
 
 ; Avoid making black market sell elerium shards and alloys.

--- a/WaveCOM/Config/XComWaveCOM.ini
+++ b/WaveCOM/Config/XComWaveCOM.ini
@@ -15,7 +15,7 @@ WaveCOMResearchSupplyCostRatio=0.1
 +CantSellResource=EleriumDust
 +CantSellResource=AlienAlloy
 
-+RepeatableUpgradeCosts=(UpgradeName=BuildSpark, SupplyIncrement=200, SupplyMax=2000, ScaleWithSquadSize=true, FirstIncrease=4)
++RepeatableUpgradeCosts=(UpgradeName=BuildSpark, SupplyIncrement=200, SupplyMax=2000, ScaleWithSquadSize=true, FirstIncrease=4, IgnoreDiscounts=true)
 
 [WaveCOM.WaveCOMStrategy]
 WaveCOMStartingSupplies=500

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOMXComGameState_BlackMarket.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOMXComGameState_BlackMarket.uc
@@ -87,7 +87,7 @@ function StrategyCost GetPersonnelForSaleItemCost(optional float CostScalar = 1.
 		ResourceCost.Quantity = class'WaveCOM_UILoadoutButton'.default.WaveCOMDeployCosts[XComCount];
 	}
 
-	ResourceCost.Quantity = Round(ResourceCost.Quantity * (100 / (100 - GoodsCostPercentDiscount))); // Counter Discount
+	ResourceCost.Quantity = Round(ResourceCost.Quantity * (100.0f / (100.0f - GoodsCostPercentDiscount))); // Counter Discount
 	Cost.ResourceCosts.AddItem(ResourceCost);
 
 	return Cost;

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_MissionLogic_WaveCOM.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_MissionLogic_WaveCOM.uc
@@ -524,7 +524,8 @@ static function FullRefreshSoldier(StateObjectReference UnitRef)
 	local StateObjectReference AbilityReference;
 	local XComGameState_HeadquartersXCom XComHQ;
 	local int i;
-
+	
+	UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
 	EffectContext = class'WaveCOMGameStateContext_UpdateUnit'.static.CreateChangeStateUU("Clean Unit State", UnitState);
 	NewGameState = EffectContext.GetGameState();
 	UnitState = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', UnitRef.ObjectID));

--- a/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
+++ b/WaveCOM/Src/WaveCOM/Classes/WaveCOM_UILoadoutButton.uc
@@ -177,7 +177,6 @@ private function int UpdateDeployCost ()
 
 private function EventListenerReturn OnDeath(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID)
 {
-	UpdateResources();
 	UpdateDeployCost();
 	return ELR_NoInterrupt;
 }
@@ -212,7 +211,7 @@ private function EventListenerReturn UpdateTechCost(Object EventData, Object Eve
 	local XComGameState_Tech TechState;
 
 	NumSoldier = UpdateDeployCost();
-	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier, `XCOMHQ.ProvingGroundPercentDiscount);
 
 	// Refresh foreground
 	ProjectScreen = UISimpleCommodityScreen(TacHUDScreen.Movie.Stack.GetFirstInstanceOf(class'UIChooseProject'));
@@ -378,7 +377,7 @@ public function OpenResearchMenu(UIButton Button)
 	local int NumSoldier;
 	UpdateResources();
 	NumSoldier = UpdateDeployCost();
-	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier, `XCOMHQ.ProvingGroundPercentDiscount);
 	LoadedScreen = TacHUDScreen.Movie.Pres.Spawn(class'UIChooseResearch', TacHUDScreen.Movie.Pres);
 	TacHUDScreen.Movie.Stack.Push(LoadedScreen, TacHUDScreen.Movie);
 }
@@ -389,7 +388,7 @@ public function OpenProjectMenu(UIButton Button)
 	local int NumSoldier;
 	UpdateResources();
 	NumSoldier = UpdateDeployCost();
-	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier);
+	class'X2DownloadableContentInfo_WaveCOM'.static.UpdateResearchCostDynamic(NumSoldier, `XCOMHQ.ProvingGroundPercentDiscount);
 	LoadedScreen = TacHUDScreen.Movie.Pres.Spawn(class'UIChooseProject', TacHUDScreen.Movie.Pres);
 	TacHUDScreen.Movie.Stack.Push(LoadedScreen, TacHUDScreen.Movie);
 }


### PR DESCRIPTION
- Fixed ability and effects FX persisting for too long after waves
- Fixed resources no longer update after spark cost update
- Fixed event listeners not initialize properly on the first wave after a map transfer (rapid fire/ ever vigilant will break)
- Hunter's axe should be visible after refilling without needing to re-equip
- Fix special ammo persisting after unequiping without re-equip weapon.
- Added attention icon on loadout button if one of the soldier can be promoted
- Added dialog for completing research/proving grounds project.
- Integrated reward decks refresher to trigger on wave ends (the mod only trigger in avenger so it doesn't work here).
- Allow tabbing through soldiers in loadout main menu
- Prevents the waveCOM UI from appearing too soon after the last enemy dies.
- Fixed a problem on Black Market config of not spawning additional tier 3 after FL 15
- Fixed resource bar appearing after a kill during wave phase
- Fixed wave start unit refresh not properly clearing debuffs sometimes
- SPARKS supply cost no longer discounted by OTS Continent Bonus.
